### PR TITLE
Remove extra newline

### DIFF
--- a/ifacemaker.go
+++ b/ifacemaker.go
@@ -36,7 +36,6 @@ func run(args *cmdlineArgs) {
 	}
 
 	result, err := maker.MakeInterface(args.PkgName, args.IfaceName, allMethods, nil)
-	result = append(result, '\n')
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
The output is already correctly formatted by goimports.
This extra newline caused the result file to be incorrectly
formatted.

Fixes #5