### PR TITLE
Comments, Tests and a little refactoring

### DIFF
--- a/maker/maker.go
+++ b/maker/maker.go
@@ -95,8 +95,8 @@ func FormatFieldList(src []byte, fl *ast.FieldList) []string {
 			names[i] = n.Name
 		}
 		t := string(src[l.Type.Pos()-1 : l.Type.End()-1])
-		typeSharingArgs := strings.Join(names, ", ")
 		if len(names) > 0 {
+			typeSharingArgs := strings.Join(names, ", ")
 			parts = append(parts, fmt.Sprintf("%s %s", typeSharingArgs, t))
 		} else {
 			parts = append(parts, t)
@@ -151,9 +151,6 @@ func MakeInterface(comment, pkgName, ifaceName, ifaceComment string, methods []s
 // isFunctionPrivate checks whether the starting
 // sign is lower case
 func isFunctionPrivate(name string) bool {
-	if len(name) == 0 {
-		return false
-	}
 	return name[0] == '_' || (name[0] >= 'a' && name[0] <= 'z')
 }
 

--- a/maker/maker.go
+++ b/maker/maker.go
@@ -150,7 +150,7 @@ func MakeInterface(comment, pkgName, ifaceName, ifaceComment string, methods []s
 
 // isFunctionPrivate checks whether the starting
 // sign is lower case
-func isFunctionPrivate(name string) bool {
+func isMethodPrivate(name string) bool {
 	return name[0] == '_' || (name[0] >= 'a' && name[0] <= 'z')
 }
 
@@ -184,7 +184,7 @@ func ParseStruct(src []byte, structName string, copyDocs bool) (methods []Method
 	for _, d := range a.Decls {
 		if a, fd := GetReceiverTypeName(src, d); a == structName {
 			methodName := fd.Name.String()
-			if isFunctionPrivate(methodName) {
+			if isMethodPrivate(methodName) {
 				continue
 			}
 			params := FormatFieldList(src, fd.Type.Params)

--- a/maker/maker.go
+++ b/maker/maker.go
@@ -28,17 +28,31 @@ func (m *Method) Lines() []string {
 	return lines
 }
 
-// GetReceiverTypeName returns the name of the
+// GetReceiverTypeName takes in the entire
+// source code and a single declaration.
+// It then checks if the declaration is a
+// function declaration, if it is, it uses
+// the GetReceiverType to check whether
+// the declaration is a method or a function
+// if it is a function we fatally stop.
+// If it is a method we retrieve the type
+// of the receiver based on the types
+// start and end pos in combination with
+// the actual source code.
+// It then returns the name of the
 // receiver type and the function declaration
+//
+// Behavior is undefined for a src []byte that
+// isn't the source of the possible FuncDecl fl
 func GetReceiverTypeName(src []byte, fl interface{}) (string, *ast.FuncDecl) {
 	fd, ok := fl.(*ast.FuncDecl)
 	if !ok {
 		return "", nil
 	}
-	if fd.Recv.NumFields() != 1 {
+	t, err := GetReceiverType(fd)
+	if err != nil {
 		return "", nil
 	}
-	t := fd.Recv.List[0].Type
 	st := string(src[t.Pos()-1 : t.End()-1])
 	if len(st) > 0 && st[0] == '*' {
 		st = st[1:]
@@ -46,35 +60,44 @@ func GetReceiverTypeName(src []byte, fl interface{}) (string, *ast.FuncDecl) {
 	return st, fd
 }
 
-// GetParameters ...
-func GetParameters(src []byte, fl *ast.FieldList) ([]string, bool) {
-	if fl == nil {
-		return nil, false
+// GetReceiverType checks if the FuncDecl
+// is a function, if it is return
+// a nil error because. If it is a method we hardcode a
+// 0 index fetch of the receiver because
+// a method can only have 1 receiver.
+// Which can make you wonder why it is a
+// list in the first place, but this type
+// from the `ast` pkg is used in other
+// places than for receivers
+func GetReceiverType(fd *ast.FuncDecl) (ast.Expr, error) {
+	if fd.Recv == nil {
+		return nil, fmt.Errorf("fd is not a method, it is a function")
 	}
-	merged := false
-	parts := []string{}
+	return fd.Recv.List[0].Type, nil
+}
 
+// FormatFieldList takes in the source code
+// as a []byte and a FuncDecl parameters or
+// return values as a FieldList.
+func FormatFieldList(src []byte, fl *ast.FieldList) []string {
+	if fl == nil {
+		return nil
+	}
+	var parts []string
 	for _, l := range fl.List {
 		names := make([]string, len(l.Names))
-		if len(names) > 1 {
-			merged = true
-		}
 		for i, n := range l.Names {
 			names[i] = n.Name
 		}
-
 		t := string(src[l.Type.Pos()-1 : l.Type.End()-1])
-
-		var v string
+		typeSharingArgs := strings.Join(names, ", ")
 		if len(names) > 0 {
-			v = fmt.Sprintf("%s %s", strings.Join(names, ", "), t)
-			merged = true
+			parts = append(parts, fmt.Sprintf("%s %s", typeSharingArgs, t))
 		} else {
-			v = t
+			parts = append(parts, t)
 		}
-		parts = append(parts, v)
 	}
-	return parts, merged || len(parts) > 1
+	return parts
 }
 
 // FormatCode sets the options of the imports
@@ -117,6 +140,15 @@ func MakeInterface(comment, pkgName, ifaceName, ifaceComment string, methods []s
 	return FormatCode(code)
 }
 
+// isFunctionPrivate checks whether the starting
+// sign is lower case
+func isFunctionPrivate(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	return name[0] == '_' || (name[0] >= 'a' && name[0] <= 'z')
+}
+
 // ParseStruct takes in a piece of source code as a
 // []byte, the name of the struct it should base the
 // interface on and a bool saying whether it should
@@ -144,22 +176,16 @@ func ParseStruct(src []byte, structName string, copyDocs bool) (methods []Method
 		}
 	}
 
-	for _, d := range a.Decls {
+	for i, d := range a.Decls {
+		fmt.Printf("%d:%+v\n", i, d)
 		if a, fd := GetReceiverTypeName(src, d); a == structName {
 			methodName := fd.Name.String()
-			if methodName[0] > 'Z' {
+			if isFunctionPrivate(methodName) {
 				continue
 			}
-			params, _ := GetParameters(src, fd.Type.Params)
-			ret, merged := GetParameters(src, fd.Type.Results)
-
-			var retValues string
-			if merged {
-				retValues = fmt.Sprintf("(%s)", strings.Join(ret, ", "))
-			} else {
-				retValues = strings.Join(ret, ", ")
-			}
-			method := fmt.Sprintf("%s(%s) %s", methodName, strings.Join(params, ", "), retValues)
+			params := FormatFieldList(src, fd.Type.Params)
+			ret := FormatFieldList(src, fd.Type.Results)
+			method := fmt.Sprintf("%s(%s) (%s)", methodName, strings.Join(params, ", "), strings.Join(ret, ", "))
 			var docs []string
 			if fd.Doc != nil && copyDocs {
 				for _, d := range fd.Doc.List {

--- a/maker/maker.go
+++ b/maker/maker.go
@@ -61,10 +61,11 @@ func GetReceiverTypeName(src []byte, fl interface{}) (string, *ast.FuncDecl) {
 }
 
 // GetReceiverType checks if the FuncDecl
-// is a function, if it is return
-// a nil error because. If it is a method we hardcode a
-// 0 index fetch of the receiver because
-// a method can only have 1 receiver.
+// is a function or a method. If it is a
+// function it returns a nil ast.Expr and
+// a non-nil err. If it is a method it uses
+// a hardcoded 0 index to fetch the receiver
+// because a method can only have 1 receiver.
 // Which can make you wonder why it is a
 // list in the first place, but this type
 // from the `ast` pkg is used in other
@@ -79,6 +80,10 @@ func GetReceiverType(fd *ast.FuncDecl) (ast.Expr, error) {
 // FormatFieldList takes in the source code
 // as a []byte and a FuncDecl parameters or
 // return values as a FieldList.
+// It then returns a []string with each
+// param or return value as a single string.
+// If the FieldList input is nil, it returns
+// nil
 func FormatFieldList(src []byte, fl *ast.FieldList) []string {
 	if fl == nil {
 		return nil
@@ -103,7 +108,10 @@ func FormatFieldList(src []byte, fl *ast.FieldList) []string {
 // FormatCode sets the options of the imports
 // pkg and then applies the Process method
 // which by default removes all of the imports
-// not used and formats the remaining
+// not used and formats the remaining docs,
+// imports and code like `gofmt`. It will
+// e.g. remove paranthesis around a unnamed
+// single return type
 func FormatCode(code string) ([]byte, error) {
 	opts := &imports.Options{
 		TabIndent: true,
@@ -176,7 +184,7 @@ func ParseStruct(src []byte, structName string, copyDocs bool) (methods []Method
 		}
 	}
 
-	for i, d := range a.Decls {
+	for _, d := range a.Decls {
 		if a, fd := GetReceiverTypeName(src, d); a == structName {
 			methodName := fd.Name.String()
 			if isFunctionPrivate(methodName) {

--- a/maker/maker.go
+++ b/maker/maker.go
@@ -177,7 +177,6 @@ func ParseStruct(src []byte, structName string, copyDocs bool) (methods []Method
 	}
 
 	for i, d := range a.Decls {
-		fmt.Printf("%d:%+v\n", i, d)
 		if a, fd := GetReceiverTypeName(src, d); a == structName {
 			methodName := fd.Name.String()
 			if isFunctionPrivate(methodName) {

--- a/maker/maker_test.go
+++ b/maker/maker_test.go
@@ -1,8 +1,73 @@
 package maker
 
 import (
+	"go/parser"
+	"go/token"
+	"log"
 	"strings"
 	"testing"
+)
+
+var (
+	src = []byte(`
+		package main
+
+		import (
+		    "fmt"
+		)
+
+		// Person ...
+		type Person struct {
+		    name string
+		    age int
+		    telephone string
+		}
+
+		// Name ...
+		func (p *Person) Name() string {
+		    return p.name
+		}
+
+		// SetName ...
+		func (p *Person) SetName(name string) {
+		    p.name = name
+		}
+
+		// Age ...
+		func (p *Person) Age() int {
+		    return p.Age
+		}
+
+		// Age ...
+		func (p *Person) SetAge(age int) int {
+		    p.Age = age
+		}
+
+		// AgeAndName ...
+		func (p *Person) AgeAndName() (int, string) {
+		    return p.age, p.name
+		}
+
+		func (p *Person) SetAgeAndName(name string, age int) {
+		    p.name = name
+		    p.age = age
+		}
+
+		// TelephoneAndName ...
+		func (p *Person) GetNameAndTelephone() (name, telephone string) {
+		    telephone = p.telephone
+		    name = p.name 
+		    return
+		}
+
+		func (p *Person) SetNameAndTelephone(name, telephone string) {
+		    p.name = name
+		    p.telephone = telephone
+		}
+
+		func SomeFunction() string {
+		    return "Something"
+		}`)
 )
 
 func check(value, pattern string, t *testing.T) {
@@ -21,25 +86,113 @@ func TestLines(t *testing.T) {
 }
 
 func TestParseStruct(t *testing.T) {
-	src := []byte(`package main
-	    
-	    import (
-		"fmt"
-	    )
-
-	    // Person ...
-	    type Person struct {
-		name string
-	    }
-
-	    // Name ...
-	    func (p *Person) Name() string {
-		return p.name
-	    }`)
 	methods, imports := ParseStruct(src, "Person", true)
-	check(methods[0].Code, "Name() string", t)
+	check(methods[0].Code, "Name() (string)", t)
 	imp := imports[0]
 	trimmedImp := strings.TrimSpace(imp)
 	expected := "\"fmt\""
 	check(trimmedImp, expected, t)
+}
+
+func TestGetReceiverTypeName(t *testing.T) {
+	fset := token.NewFileSet()
+	a, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	hasPersonFuncDecl := false
+	for _, d := range a.Decls {
+		typeName, fd := GetReceiverTypeName(src, d)
+		if typeName == "" {
+			continue
+		}
+		switch typeName {
+		case "Person":
+			if fd == nil {
+				t.Fatalf("receiver type with name %s had a nil func decl", typeName)
+			}
+			// OK
+			hasPersonFuncDecl = true
+		}
+	}
+	if !hasPersonFuncDecl {
+		t.Fatalf("Never registered a func decl with the `Person` receiver type")
+	}
+}
+
+func TestIsFunctionPrivate(t *testing.T) {
+	functionNames := map[string]bool{"_someFunc": true, "herp": true, "_SomeFunc": true, "SomeFunc": false, "ZooFunc": false}
+	for name, expected := range functionNames {
+		if isFunctionPrivate(name) != expected {
+			t.Fatalf("Function name %s != expected value %+v", name, expected)
+		}
+	}
+
+}
+
+func TestFormatFieldList(t *testing.T) {
+	fset := token.NewFileSet()
+	a, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	for _, d := range a.Decls {
+		if a, fd := GetReceiverTypeName(src, d); a == "Person" {
+			methodName := fd.Name.String()
+			params := FormatFieldList(src, fd.Type.Params)
+			results := FormatFieldList(src, fd.Type.Results)
+			switch methodName {
+			case "Name":
+				expectedParam := []string{}
+				expectedResults := []string{"string"}
+				if !compare(expectedParam, params, t) || !compare(expectedResults, results, t) {
+					t.Fatalf("Name did not have the expected params and/or results")
+				}
+			case "Age":
+				expectedParams := []string{}
+				expectedResults := []string{"int"}
+				if !compare(expectedParams, params, t) || !compare(expectedResults, results, t) {
+					t.Fatalf("Age did not have the expected params and/or results")
+				}
+			case "SetName":
+				expectedParams := []string{"name string"}
+				expectedResults := []string{}
+				if !compare(expectedParams, params, t) || !compare(expectedResults, results, t) {
+					t.Fatalf("SetName did not have the expected params and/or results")
+				}
+			case "SetAgeAndName":
+				expectedParams := []string{"name string", "age int"}
+				expectedResults := []string{}
+				if !compare(expectedParams, params, t) || !compare(expectedResults, results, t) {
+					t.Fatalf("SetAgeAndName did not have the expected params and/or results")
+				}
+			case "GetNameAndTelephone":
+				expectedParams := []string{}
+				expectedResults := []string{"name, telephone string"}
+				if !compare(expectedParams, params, t) || !compare(expectedResults, results, t) {
+					t.Fatalf("GetNameAndTelephone did not have the expected params and/or results")
+				}
+			case "SetNameAndTelephone":
+				expectedParams := []string{"name, telephone string"}
+				expectedResults := []string{}
+				if !compare(expectedParams, params, t) || !compare(expectedResults, results, t) {
+					t.Fatalf("SetNameAndTelephone did not have the expected params and/or results")
+				}
+			}
+		}
+	}
+}
+
+func compare(actual []string, expected []string, t *testing.T) bool {
+	if len(actual) != len(expected) {
+		t.Logf("Compare received two different lengths of fields, expected:|%+v| was not equal to actual |%+v|. actual length:%d, expected length:%d", expected, actual, len(actual), len(expected))
+		return false
+	}
+	for i := 0; i < len(actual); i++ {
+		if actual[i] != expected[i] {
+			t.Logf("Compare expected:|%+v| was not equal to actual |%+v|", expected, actual)
+			return false
+		}
+	}
+	return true
 }

--- a/maker/maker_test.go
+++ b/maker/maker_test.go
@@ -120,10 +120,10 @@ func TestGetReceiverTypeName(t *testing.T) {
 	}
 }
 
-func TestIsFunctionPrivate(t *testing.T) {
+func TestIsMethodPrivate(t *testing.T) {
 	functionNames := map[string]bool{"_someFunc": true, "herp": true, "_SomeFunc": true, "SomeFunc": false, "ZooFunc": false}
 	for name, expected := range functionNames {
-		if isFunctionPrivate(name) != expected {
+		if isMethodPrivate(name) != expected {
 			t.Fatalf("Function name %s != expected value %+v", name, expected)
 		}
 	}

--- a/maker/maker_test.go
+++ b/maker/maker_test.go
@@ -70,7 +70,7 @@ var (
 		}`)
 )
 
-func check(value, pattern string, t *testing.T) {
+func mustBeEqual(value, pattern string, t *testing.T) {
 	if value != pattern {
 		t.Fatalf("Value %s did not match expected pattern %s", value, pattern)
 	}
@@ -81,17 +81,17 @@ func TestLines(t *testing.T) {
 	code := `func TestMethod() string {return "I am great"}`
 	method := Method{Code: code, Docs: docs}
 	lines := method.Lines()
-	check(lines[0], "// TestMethod is great", t)
-	check(lines[1], "func TestMethod() string {return \"I am great\"}", t)
+	mustBeEqual(lines[0], "// TestMethod is great", t)
+	mustBeEqual(lines[1], "func TestMethod() string {return \"I am great\"}", t)
 }
 
 func TestParseStruct(t *testing.T) {
 	methods, imports := ParseStruct(src, "Person", true)
-	check(methods[0].Code, "Name() (string)", t)
+	mustBeEqual(methods[0].Code, "Name() (string)", t)
 	imp := imports[0]
 	trimmedImp := strings.TrimSpace(imp)
 	expected := "\"fmt\""
-	check(trimmedImp, expected, t)
+	mustBeEqual(trimmedImp, expected, t)
 }
 
 func TestGetReceiverTypeName(t *testing.T) {
@@ -145,37 +145,37 @@ func TestFormatFieldList(t *testing.T) {
 			case "Name":
 				expectedParam := []string{}
 				expectedResults := []string{"string"}
-				if !compare(expectedParam, params, t) || !compare(expectedResults, results, t) {
+				if !compareStrArrays(expectedParam, params, t) || !compareStrArrays(expectedResults, results, t) {
 					t.Fatalf("Name did not have the expected params and/or results")
 				}
 			case "Age":
 				expectedParams := []string{}
 				expectedResults := []string{"int"}
-				if !compare(expectedParams, params, t) || !compare(expectedResults, results, t) {
+				if !compareStrArrays(expectedParams, params, t) || !compareStrArrays(expectedResults, results, t) {
 					t.Fatalf("Age did not have the expected params and/or results")
 				}
 			case "SetName":
 				expectedParams := []string{"name string"}
 				expectedResults := []string{}
-				if !compare(expectedParams, params, t) || !compare(expectedResults, results, t) {
+				if !compareStrArrays(expectedParams, params, t) || !compareStrArrays(expectedResults, results, t) {
 					t.Fatalf("SetName did not have the expected params and/or results")
 				}
 			case "SetAgeAndName":
 				expectedParams := []string{"name string", "age int"}
 				expectedResults := []string{}
-				if !compare(expectedParams, params, t) || !compare(expectedResults, results, t) {
+				if !compareStrArrays(expectedParams, params, t) || !compareStrArrays(expectedResults, results, t) {
 					t.Fatalf("SetAgeAndName did not have the expected params and/or results")
 				}
 			case "GetNameAndTelephone":
 				expectedParams := []string{}
 				expectedResults := []string{"name, telephone string"}
-				if !compare(expectedParams, params, t) || !compare(expectedResults, results, t) {
+				if !compareStrArrays(expectedParams, params, t) || !compareStrArrays(expectedResults, results, t) {
 					t.Fatalf("GetNameAndTelephone did not have the expected params and/or results")
 				}
 			case "SetNameAndTelephone":
 				expectedParams := []string{"name, telephone string"}
 				expectedResults := []string{}
-				if !compare(expectedParams, params, t) || !compare(expectedResults, results, t) {
+				if !compareStrArrays(expectedParams, params, t) || !compareStrArrays(expectedResults, results, t) {
 					t.Fatalf("SetNameAndTelephone did not have the expected params and/or results")
 				}
 			}
@@ -183,14 +183,14 @@ func TestFormatFieldList(t *testing.T) {
 	}
 }
 
-func compare(actual []string, expected []string, t *testing.T) bool {
+func compareStrArrays(actual []string, expected []string, t *testing.T) bool {
 	if len(actual) != len(expected) {
-		t.Logf("Compare received two different lengths of fields, expected:|%+v| was not equal to actual |%+v|. actual length:%d, expected length:%d", expected, actual, len(actual), len(expected))
+		t.Logf("compareStrArrays received two different lengths of fields, expected:|%+v| was not equal to actual |%+v|. actual length:%d, expected length:%d", expected, actual, len(actual), len(expected))
 		return false
 	}
 	for i := 0; i < len(actual); i++ {
 		if actual[i] != expected[i] {
-			t.Logf("Compare expected:|%+v| was not equal to actual |%+v|", expected, actual)
+			t.Logf("compareStrArrays expected:|%+v| was not equal to actual |%+v|", expected, actual)
 			return false
 		}
 	}


### PR DESCRIPTION
Fixed #22 which was kind of a bug converting
all named return values to unnamed return
values in the interface.

GetParameters was used for both return values
and parameters which was a little confusing
i thouth, so i changed the name of it.
The parameters use of it also threw away
the merged boolean, which i didnt like
too much, so decided to get rid of the
merged boolean, because it was only
used to wrap the return values in
paranthesis or not. Now we just always
wrap return values in paranthesis
because the FormatCode just removes
them anyway.

Impl a new method GetReceiverType
which checks if the receiver is nil
to decide whether the FuncDecl
is a method or a function. The
other impl by calling GetFields
was also ok, because it was guarded
against getting called on a nil
FuncDecl.Recv object, but i think
it is cleaner just to check it
yourself.

New implementation of the private
function check to make the logic
of the check explicit.

Also adding some unit tests for some
of the old and new methods.