### PR TITLE
CLI: Add 'type-doc' option to copy struct doc to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ Here is the help output of ifacemaker:
 $ ifacemaker --help
 Options:
 
-  -h, --help           display help information
-  -f, --file          *Go source file to read
-  -s, --struct        *Generate an interface for this structure name
-  -i, --iface         *Name of the generated interface
-  -p, --pkg           *Package name for the generated interface
-  -y, --iface-comment  Comment for the interface, default is '// <iface> ...'
-  -d, --doc[=true]     Copy docs from methods
-  -o, --output         Output file name. If not provided, result will be printed to stdout.
-  -c, --comment        Append comment to top
+  -h, --help            display help information
+  -f, --file           *Go source file to read
+  -s, --struct         *Generate an interface for this structure name
+  -i, --iface          *Name of the generated interface
+  -p, --pkg            *Package name for the generated interface
+  -y, --iface-comment   Comment for the interface, default is '// <iface> ...'
+  -d, --doc[=true]      Copy docs from methods
+  -D, --type-doc        Copy type doc from struct
+  -c, --comment         Append comment to top
+  -o, --output          Output file name. If not provided, result will be printed to stdout.
 $
 ```
 

--- a/ifacemaker_test.go
+++ b/ifacemaker_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+var src = `package main
+
+import (
+	"fmt"
+)
+
+// Person contains data related to a person.
+type Person struct {
+	name string
+	age int
+	telephone string
+}
+
+// Name ...
+func (p *Person) Name() string {
+	return p.name
+}
+
+// SetName ...
+func (p *Person) SetName(name string) {
+	p.name = name
+}
+
+// Age ...
+func (p *Person) Age() int {
+	return p.Age
+}
+
+// Age ...
+func (p *Person) SetAge(age int) int {
+	p.Age = age
+}
+
+// AgeAndName ...
+func (p *Person) AgeAndName() (int, string) {
+	return p.age, p.name
+}
+
+func (p *Person) SetAgeAndName(name string, age int) {
+	p.name = name
+	p.age = age
+}
+
+// TelephoneAndName ...
+func (p *Person) GetNameAndTelephone() (name, telephone string) {
+	telephone = p.telephone
+	name = p.name 
+	return
+}
+
+func (p *Person) SetNameAndTelephone(name, telephone string) {
+	p.name = name
+	p.telephone = telephone
+}
+
+func SomeFunction() string {
+	return "Something"
+}`
+
+var srcFile = os.TempDir() + "/ifacemaker_src.go"
+
+func TestMain(m *testing.M) {
+	writeTestSourceFile()
+
+	os.Exit(m.Run())
+}
+
+func writeTestSourceFile() {
+	f, err := os.OpenFile(srcFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModeTemporary)
+	if err != nil {
+		panic("Failed to open test source file.")
+	}
+	defer f.Close()
+	_, err = f.WriteString(src)
+	if err != nil {
+		panic("Failed to write to test source file.")
+	}
+}
+
+func TestMainAllArgs(t *testing.T) {
+	os.Args = []string{"cmd", "-f", srcFile, "-s", "Person", "-p", "gen", "-c", "DO NOT EDIT: Auto generated", "-i", "PersonIface", "-y", "PersonIface is an interface for Person.", "-D"}
+	out := captureStdout(func() {
+		main()
+	})
+
+	expected := `// DO NOT EDIT: Auto generated
+
+package gen
+
+// PersonIface is an interface for Person.
+// Person contains data related to a person.
+type PersonIface interface {
+	// Name ...
+	Name() string
+	// SetName ...
+	SetName(name string)
+	// Age ...
+	Age() int
+	// Age ...
+	SetAge(age int) int
+	// AgeAndName ...
+	AgeAndName() (int, string)
+	SetAgeAndName(name string, age int)
+	// TelephoneAndName ...
+	GetNameAndTelephone() (name, telephone string)
+	SetNameAndTelephone(name, telephone string)
+}
+
+`
+
+	mustBeEqual(out, expected, t)
+}
+
+func TestMainNoIfaceComment(t *testing.T) {
+	os.Args = []string{"cmd", "-f", srcFile, "-s", "Person", "-p", "gen", "-c", "DO NOT EDIT: Auto generated", "-i", "PersonIface", "-D"}
+	out := captureStdout(func() {
+		main()
+	})
+
+	expected := `// DO NOT EDIT: Auto generated
+
+package gen
+
+// PersonIface ...
+// Person contains data related to a person.
+type PersonIface interface {
+	// Name ...
+	Name() string
+	// SetName ...
+	SetName(name string)
+	// Age ...
+	Age() int
+	// Age ...
+	SetAge(age int) int
+	// AgeAndName ...
+	AgeAndName() (int, string)
+	SetAgeAndName(name string, age int)
+	// TelephoneAndName ...
+	GetNameAndTelephone() (name, telephone string)
+	SetNameAndTelephone(name, telephone string)
+}
+
+`
+
+	mustBeEqual(out, expected, t)
+}
+
+func TestMainNoCopyTypeDocs(t *testing.T) {
+	os.Args = []string{"cmd", "-f", srcFile, "-s", "Person", "-p", "gen", "-c", "DO NOT EDIT: Auto generated", "-i", "PersonIface", "-y", "PersonIface is an interface for Person."}
+	out := captureStdout(func() {
+		main()
+	})
+
+	expected := `// DO NOT EDIT: Auto generated
+
+package gen
+
+// PersonIface is an interface for Person.
+type PersonIface interface {
+	// Name ...
+	Name() string
+	// SetName ...
+	SetName(name string)
+	// Age ...
+	Age() int
+	// Age ...
+	SetAge(age int) int
+	// AgeAndName ...
+	AgeAndName() (int, string)
+	SetAgeAndName(name string, age int)
+	// TelephoneAndName ...
+	GetNameAndTelephone() (name, telephone string)
+	SetNameAndTelephone(name, telephone string)
+}
+
+`
+
+	mustBeEqual(out, expected, t)
+}
+
+func mustBeEqual(value, pattern string, t *testing.T) {
+	if value != pattern {
+		t.Fatalf("Value %s did not match expected pattern %s", value, pattern)
+	}
+}
+
+// not thread safe
+func captureStdout(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}


### PR DESCRIPTION
## Change

This PR adds a new CLI option `--type-doc` (`-D`).
When this flag is set the generated interface will have the struct's documentation appended to it's own.

Due to necessity this PR enables multi-line interface-comments for `-y`.

Fixes #25 

I'm not sure if it would be a good idea to search/replace the original struct name in the interface doc - it could have some unwanted side-effects in some cases.

### Example A (with `-y`):

```
// MyType can do some interesting stuff.
type MyType struct {
}
```

`ifacemaker -f mytype.go -s MyType -D -y "MyInterface is an interface for MyType, intended to be used when mockability is needed." -i MyInterface`

```
// MyInterface is an interface for MyType, intended to be used when mockability is needed.
// MyType can do some interesting stuff.
type MyInterface struct {
}
```

### Example B (no `-y`):

```
// MyType can do some interesting stuff.
type MyType struct {
}
```

`ifacemaker -f mytype.go -s MyType --type-doc -i MyInterface`

```
// MyInterface ...
// MyType can do some interesting stuff.
type MyInterface struct {
}
```