### PR TITLE
ci: Add travis.yml and run GoReleaser on tags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,30 @@
+before:
+  hooks:
+    - go mod download
+builds:
+- env:
+  - CGO_ENABLED=0
+  goos:
+    - linux
+    - darwin
+    - windows
+  goarch:
+    - 386
+    - amd64
+archive:
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,11 @@ install:
 
 script:
   - go test -cover ./...
+
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL https://git.io/goreleaser | bash
+  on:
+    tags: true
+    condition: $TRAVIS_GO_VERSION =~ ^1\.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+sudo: required
+
+go:
+  - 1.11.x
+  - stable
+  - master
+
+matrix:
+  # Failing on the development version of Go isn't too bad.
+  allow_failures:
+    - go: master
+
+env:
+  - GO111MODULE=on
+
+# Override Travis's default 'go get' step, since we use Go modules
+install:
+  - go mod download
+
+script:
+  - go test -cover ./...

--- a/ifacemaker_test.go
+++ b/ifacemaker_test.go
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 }
 
 func writeTestSourceFile() {
-	f, err := os.OpenFile(srcFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModeTemporary)
+	f, err := os.OpenFile(srcFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		panic("Failed to open test source file.")
 	}


### PR DESCRIPTION
This adds a Travis CI config that runs GoReleaser on tags.

Example Build:
https://travis-ci.org/markus-wa/ifacemaker/jobs/462909911 

Generated Release:
https://github.com/markus-wa/ifacemaker/releases/tag/v0.1.0

What needs to be done from your end for this to work:
- Configure Travis: https://travis-ci.com/getting_started
- Configure GITHUB_TOKEN environment variable in Travis: https://docs.travis-ci.com/user/deployment/pages/#setting-the-github-token
- Create a first tag (I'd suggest `v0.1.0` to not be too concerned with backwards compatibility for a start)
- Maybe more, it feels like there's something missing  :sweat_smile: 