### PR TITLE
test: use stretchr/testify/assert for assertions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mkideal/cli v0.0.2
 	github.com/mkideal/pkg v0.0.0-20170503154153-3e188c9e7ecc // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2 // indirect
+	github.com/stretchr/testify v1.2.2
 	golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85 // indirect
 	golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35 // indirect
 	golang.org/x/tools v0.0.0-20181201035826-d0ca3933b724

--- a/ifacemaker_test.go
+++ b/ifacemaker_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"testing"
+
+	assert "github.com/stretchr/testify/assert"
 )
 
 var src = `package main
@@ -117,7 +119,7 @@ type PersonIface interface {
 
 `
 
-	mustBeEqual(out, expected, t)
+	assert.Equal(t, expected, out)
 }
 
 func TestMainNoIfaceComment(t *testing.T) {
@@ -151,7 +153,7 @@ type PersonIface interface {
 
 `
 
-	mustBeEqual(out, expected, t)
+	assert.Equal(t, expected, out)
 }
 
 func TestMainNoCopyTypeDocs(t *testing.T) {
@@ -184,13 +186,7 @@ type PersonIface interface {
 
 `
 
-	mustBeEqual(out, expected, t)
-}
-
-func mustBeEqual(value, pattern string, t *testing.T) {
-	if value != pattern {
-		t.Fatalf("Value %s did not match expected pattern %s", value, pattern)
-	}
+	assert.Equal(t, expected, out)
 }
 
 // not thread safe


### PR DESCRIPTION
This simplifies many tests and makes it more clear what the expected outcome is.
It also gives a very readable diff output if the ouptut isn't as expected.

I'm working on another PR and it's making it much easier to see at a glance what exactly broke after a change.

Example diff output from the test log:
```
                            Diff:
                                --- Expected
                                +++ Actual
                                @@ -7,14 +7,8 @@
                                 type PersonIface interface {
                                -       // Name ...
                                        Name() string
                                -       // SetName ...
                                        SetName(name string)
                                -       // Age ...
                                        Age() int
                                -       // Age ...
                                        SetAge(age int) int
                                -       // AgeAndName ...
                                        AgeAndName() (int, string)
                                        SetAgeAndName(name string, age int)
                                -       // TelephoneAndName ...
                                        GetNameAndTelephone() (name, telephone string)
```