### PR TITLE
Adds flag to skip re-import by target package name.

### DIFF
--- a/ifacemaker.go
+++ b/ifacemaker.go
@@ -25,6 +25,9 @@ type cmdlineArgs struct {
 	CopyTypeDoc bool   `short:"D" long:"type-doc" description:"Copy type doc from struct"`
 	Comment     string `short:"c" long:"comment" description:"Append comment to top"`
 	Output      string `short:"o" long:"output" description:"Output file name. If not provided, result will be printed to stdout."`
+
+	ImportSameName string `short:"N" long:"import-same-name" description:"Import types by the same name as the target package." option:"true" option:"false" default:"true"`
+	importSameName bool
 }
 
 func run(args cmdlineArgs) {
@@ -38,7 +41,7 @@ func run(args cmdlineArgs) {
 		if err != nil {
 			log.Fatal(err.Error())
 		}
-		methods, imports, parsedTypeDoc := maker.ParseStruct(src, args.StructType, args.copyDocs, args.CopyTypeDoc)
+		methods, imports, parsedTypeDoc := maker.ParseStruct(src, args.StructType, args.copyDocs, args.CopyTypeDoc, args.PkgName, args.importSameName)
 		for _, m := range methods {
 			if _, ok := mset[m.Code]; !ok {
 				allMethods = append(allMethods, m.Lines()...)
@@ -85,6 +88,7 @@ func main() {
 
 	// Workaround because jessevdk/go-flags doesn't support default values for boolean flags
 	args.copyDocs = args.CopyDocs == "true"
+	args.importSameName = args.ImportSameName == "true"
 
 	if args.IfaceComment == "" {
 		args.IfaceComment = fmt.Sprintf("%s ...", args.IfaceName)

--- a/ifacemaker_test.go
+++ b/ifacemaker_test.go
@@ -216,6 +216,52 @@ type PersonIface interface {
 	assert.Equal(t, expected, out)
 }
 
+func TestMainDoNotImportPackageName(t *testing.T) {
+	os.Args = []string{"cmd", "-f", "maker/test_impl.go", "-s", "TestImpl", "-p", "footest", "-c", "DO NOT EDIT: Auto generated", "-i", "TestInterface", "-N", "false", "-d=false"}
+	out := captureStdout(func() {
+		main()
+	})
+
+	expected := `// DO NOT EDIT: Auto generated
+
+package footest
+
+// TestInterface ...
+type TestInterface interface {
+	GetUser(userID string) *User
+	CreateUser(user *User) (*User, error)
+}
+
+`
+
+	assert.Equal(t, expected, out)
+}
+
+func TestMainImportPackageName(t *testing.T) {
+	os.Args = []string{"cmd", "-f", "maker/test_impl.go", "-s", "TestImpl", "-p", "footest", "-c", "DO NOT EDIT: Auto generated", "-i", "TestInterface", "-d=false"}
+	out := captureStdout(func() {
+		main()
+	})
+
+	expected := `// DO NOT EDIT: Auto generated
+
+package footest
+
+import (
+	"github.com/vburenin/ifacemaker/maker/footest"
+)
+
+// TestInterface ...
+type TestInterface interface {
+	GetUser(userID string) *footest.User
+	CreateUser(user *footest.User) (*footest.User, error)
+}
+
+`
+
+	assert.Equal(t, expected, out)
+}
+
 // not thread safe
 func captureStdout(f func()) string {
 	old := os.Stdout

--- a/maker/footest/footest.go
+++ b/maker/footest/footest.go
@@ -1,0 +1,6 @@
+package footest
+
+type User struct {
+	ID   string
+	Name string
+}

--- a/maker/maker_test.go
+++ b/maker/maker_test.go
@@ -83,7 +83,7 @@ func TestLines(t *testing.T) {
 }
 
 func TestParseStruct(t *testing.T) {
-	methods, imports, typeDoc := ParseStruct(src, "Person", true, true)
+	methods, imports, typeDoc := ParseStruct(src, "Person", true, true, "", true)
 
 	assert.Equal(t, "Name() (string)", methods[0].Code)
 
@@ -131,8 +131,8 @@ func TestFormatFieldList(t *testing.T) {
 	for _, d := range a.Decls {
 		if a, fd := GetReceiverTypeName(src, d); a == "Person" {
 			methodName := fd.Name.String()
-			params := FormatFieldList(src, fd.Type.Params)
-			results := FormatFieldList(src, fd.Type.Results)
+			params := FormatFieldList(src, fd.Type.Params, nil)
+			results := FormatFieldList(src, fd.Type.Results, nil)
 
 			var expectedParams []string
 			var expectedResults []string
@@ -161,7 +161,7 @@ func TestFormatFieldList(t *testing.T) {
 }
 
 func TestNoCopyTypeDocs(t *testing.T) {
-	_, _, typeDoc := ParseStruct(src, "Person", true, false)
+	_, _, typeDoc := ParseStruct(src, "Person", true, false, "", true)
 	assert.Equal(t, "", typeDoc)
 }
 

--- a/maker/test_impl.go
+++ b/maker/test_impl.go
@@ -1,0 +1,19 @@
+package maker
+
+import (
+	"github.com/vburenin/ifacemaker/maker/footest"
+)
+
+type TestImpl struct{}
+
+func (s *TestImpl) GetUser(userID string) *footest.User {
+	return &footest.User{}
+}
+
+func (s *TestImpl) CreateUser(user *footest.User) (*footest.User, error) {
+	return &footest.User{}, nil
+}
+
+func (s *TestImpl) fooHelper() string {
+	return ""
+}


### PR DESCRIPTION
Importing to the same target package name as one of the imported types in the source implementation struct can lead to an import cycle in the generated code. There's a simple example in the added tests. This PR adds a new optional flag `-N`/`--import-same-name` which — if left unset — will behave the same as usual, but allows users with the outlined scenario to use this tool.