### PR TITLE
Type check input source code.

### DIFF
--- a/ifacemaker.go
+++ b/ifacemaker.go
@@ -38,7 +38,10 @@ func run(args cmdlineArgs) {
 		if err != nil {
 			log.Fatal(err.Error())
 		}
-		methods, imports, parsedTypeDoc := maker.ParseStruct(src, args.StructType, args.copyDocs, args.CopyTypeDoc)
+		methods, imports, parsedTypeDoc, err := maker.ParseStruct(src, args.StructType, args.copyDocs, args.CopyTypeDoc)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
 		for _, m := range methods {
 			if _, ok := mset[m.Code]; !ok {
 				allMethods = append(allMethods, m.Lines()...)

--- a/ifacemaker_test.go
+++ b/ifacemaker_test.go
@@ -11,10 +11,6 @@ import (
 
 var src = `package main
 
-import (
-	"fmt"
-)
-
 // Person contains data related to a person.
 type Person struct {
 	name string
@@ -34,12 +30,13 @@ func (p *Person) SetName(name string) {
 
 // Age ...
 func (p *Person) Age() int {
-	return p.Age
+	return p.age
 }
 
 // Age ...
 func (p *Person) SetAge(age int) int {
-	p.Age = age
+	p.age = age
+	return age
 }
 
 // AgeAndName ...


### PR DESCRIPTION
I noticed that the existing tests were using invalid source code. If that's by design for some reason then we can close this PR but it seems to be consistent with Go practices to not accept "garbage in".