### PR TITLE
Only adds a comment line to interface if the param is not an empty string.

### DIFF
--- a/maker/maker.go
+++ b/maker/maker.go
@@ -140,9 +140,11 @@ func MakeInterface(comment, pkgName, ifaceName, ifaceComment string, methods []s
 	output = append(output,
 		")",
 		"",
-		fmt.Sprintf("// %s", strings.Replace(ifaceComment, "\n", "\n// ", -1)),
-		fmt.Sprintf("type %s interface {", ifaceName),
 	)
+	if len(ifaceComment) > 0 {
+		output = append(output, fmt.Sprintf("// %s", strings.Replace(ifaceComment, "\n", "\n// ", -1)))
+	}
+	output = append(output, fmt.Sprintf("type %s interface {", ifaceName))
 	output = append(output, methods...)
 	output = append(output, "}")
 	code := strings.Join(output, "\n")

--- a/maker/maker_test.go
+++ b/maker/maker_test.go
@@ -189,6 +189,29 @@ type MyInterface interface {
 	assert.Equal(t, expected, string(b))
 }
 
+func TestMakeWithoutInterfaceComment(t *testing.T) {
+	methods := []string{"// MyMethod does cool stuff", "MyMethod(string) example.Example"}
+	imports := []string{`"github.com/example/example"`}
+	b, err := MakeInterface("DO NOT EDIT: Auto generated", "pkg", "MyInterface", "", methods, imports)
+	assert.Nil(t, err, "MakeInterface returned an error")
+
+	expected := `// DO NOT EDIT: Auto generated
+
+package pkg
+
+import (
+	"github.com/example/example"
+)
+
+type MyInterface interface {
+	// MyMethod does cool stuff
+	MyMethod(string) example.Example
+}
+`
+
+	assert.Equal(t, expected, string(b))
+}
+
 func TestMakeInterfaceMultiLineIfaceComment(t *testing.T) {
 	b, err := MakeInterface("DO NOT EDIT: Auto generated", "pkg", "MyInterface", "MyInterface does cool stuff.\nWith multi-line comments.", nil, nil)
 	assert.Nil(t, err, "MakeInterface returned an error:", err)


### PR DESCRIPTION
Prevents having `//` above the generated interface if there's no interface comment specified.