### PR TITLE
Fix imported packages ending with the name of the current package being incorrectly replaced

### DIFF
--- a/maker/maker.go
+++ b/maker/maker.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"io/ioutil"
 	"log"
+	"regexp"
 	"strings"
 
 	"golang.org/x/tools/imports"
@@ -97,7 +98,10 @@ func FormatFieldList(src []byte, fl *ast.FieldList, pkgName string) []string {
 			names[i] = n.Name
 		}
 		t := string(src[l.Type.Pos()-1 : l.Type.End()-1])
-		t = strings.Replace(t, pkgName+".", "", -1)
+
+		regexString := fmt.Sprintf(`(\*|\(|\s|^)%s\.`, regexp.QuoteMeta(pkgName))
+		t = regexp.MustCompile(regexString).ReplaceAllString(t, "$1")
+
 		if len(names) > 0 {
 			typeSharingArgs := strings.Join(names, ", ")
 			parts = append(parts, fmt.Sprintf("%s %s", typeSharingArgs, t))

--- a/maker/maker_test.go
+++ b/maker/maker_test.go
@@ -112,7 +112,7 @@ func TestParseStruct(t *testing.T) {
 	imp := imports[0]
 	trimmedImp := strings.TrimSpace(imp)
 
-	assert.Equal(t, `"fmt"`, trimmedImp)
+	assert.Equal(t, `notmain "fmt"`, trimmedImp)
 	assert.Equal(t, "Person ...", typeDoc)
 }
 

--- a/maker/maker_test.go
+++ b/maker/maker_test.go
@@ -11,64 +11,86 @@ import (
 
 var (
 	src = []byte(`
-		package main
+	package main
 
-		import (
-		    "fmt"
-		)
-
-		// Person ...
-		type Person struct {
-		    name string
-		    age int
-		    telephone string
-		}
-
-		// Name ...
-		func (p *Person) Name() string {
-		    return p.name
-		}
-
-		// SetName ...
-		func (p *Person) SetName(name string) {
-		    p.name = name
-		}
-
-		// Age ...
-		func (p *Person) Age() int {
-		    return p.Age
-		}
-
-		// Age ...
-		func (p *Person) SetAge(age int) {
-		    p.Age = age
-		}
-
-		// AgeAndName ...
-		func (p *Person) AgeAndName() (int, string) {
-		    return p.age, p.name
-		}
-
-		func (p *Person) SetAgeAndName(name string, age int) {
-		    p.name = name
-		    p.age = age
-		}
-
-		// TelephoneAndName ...
-		func (p *Person) GetNameAndTelephone() (name, telephone string) {
-		    telephone = p.telephone
-		    name = p.name 
-		    return
-		}
-
-		func (p *Person) SetNameAndTelephone(name, telephone string) {
-		    p.name = name
-		    p.telephone = telephone
-		}
-
-		func SomeFunction() string {
-		    return "Something"
-		}`)
+	import (
+		notmain "fmt"
+	)
+	
+	// Person ...
+	type Person struct {
+		name string
+		age int
+		telephone string
+		noPointer notmain.Formatter
+		pointer *notmain.Formatter
+	}
+	
+	// Name ...
+	func (p *Person) Name() string {
+		return p.name
+	}
+	
+	// SetName ...
+	func (p *Person) SetName(name string) {
+		p.name = name
+	}
+	
+	// Age ...
+	func (p *Person) Age() int {
+		return p.Age
+	}
+	
+	// Age ...
+	func (p *Person) SetAge(age int) {
+		p.Age = age
+	}
+	
+	// AgeAndName ...
+	func (p *Person) AgeAndName() (int, string) {
+		return p.age, p.name
+	}
+	
+	func (p *Person) SetAgeAndName(name string, age int) {
+		p.name = name
+		p.age = age
+	}
+	
+	// TelephoneAndName ...
+	func (p *Person) GetNameAndTelephone() (name, telephone string) {
+		telephone = p.telephone
+		name = p.name
+		return
+	}
+	
+	func (p *Person) SetNameAndTelephone(name, telephone string) {
+		p.name = name
+		p.telephone = telephone
+	}
+	
+	func (p *Person) ReturnPointer() *notmain.Formatter {
+		return nil
+	}
+	
+	func (p *Person) ReturnNoPointer() notmain.Formatter {
+		return nil
+	}
+	
+	func (p *Person) ArgumentNoPointer(formatter notmain.Formatter)  {
+	
+	}
+	
+	func (p *Person) ArgumentPointer(formatter *notmain.Formatter)  {
+	
+	}
+	
+	func (p *Person) SecondArgumentPointer(abc int, formatter *notmain.Formatter)  {
+	
+	}
+	
+	func SomeFunction() string {
+		return "Something"
+	}`)
 )
 
 func TestLines(t *testing.T) {
@@ -124,8 +146,8 @@ func TestFormatFieldList(t *testing.T) {
 	for _, d := range a.Decls {
 		if a, fd := GetReceiverTypeName(src, d); a == "Person" {
 			methodName := fd.Name.String()
-			params := FormatFieldList(src, fd.Type.Params, "")
-			results := FormatFieldList(src, fd.Type.Results, "")
+			params := FormatFieldList(src, fd.Type.Params, "main")
+			results := FormatFieldList(src, fd.Type.Results, "main")
 
 			var expectedParams []string
 			var expectedResults []string
@@ -146,6 +168,16 @@ func TestFormatFieldList(t *testing.T) {
 				expectedResults = []string{"name, telephone string"}
 			case "SetNameAndTelephone":
 				expectedParams = []string{"name, telephone string"}
+			case "ReturnPointer":
+				expectedResults = []string{"*notmain.Formatter"}
+			case "ReturnNoPointer":
+				expectedResults = []string{"notmain.Formatter"}
+			case "ArgumentNoPointer":
+				expectedParams = []string{"formatter notmain.Formatter"}
+			case "ArgumentPointer":
+				expectedParams = []string{"formatter *notmain.Formatter"}
+			case "SecondArgumentPointer":
+				expectedParams = []string{"abc int", "formatter *notmain.Formatter"}
 			}
 			assert.Equalf(t, expectedParams, params, "%s must have the expected params", methodName)
 			assert.Equalf(t, expectedResults, results, "%s must have the expected results", methodName)


### PR DESCRIPTION
Fixes #42. I've modified a test too to test the scenario the bug was present in. I wasn't sure how you were laying out the tests so I just added it a relevant test. Please let me know if you want me to change that.