### PR TITLE
Update README.md to use "go install" instead of "go get".

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ makes unit testing easier.
 ## Install
 
 ```
-go get github.com/vburenin/ifacemaker
+go install github.com/vburenin/ifacemaker@latest
 ```
 
 ## Usage


### PR DESCRIPTION
https://go.dev/doc/go-get-install-deprecation