### PR TITLE
Fix struct validation for multiple files

### DIFF
--- a/maker/maker.go
+++ b/maker/maker.go
@@ -341,18 +341,18 @@ func Make(options MakeOptions) ([]byte, error) {
 			return []byte{}, err
 		}
 		types := ParseDeclaredTypes(b)
-		// validate structs from file against input struct Type
-		if !validateStructType(types, options.StructType) {
-			return []byte{},
-				fmt.Errorf("%q structtype not found in input files",
-					options.StructType)
-		}
 		for _, t := range types {
 			if _, ok := tset[t.Fullname()]; !ok {
 				allDeclaredTypes = append(allDeclaredTypes, t)
 				tset[t.Fullname()] = struct{}{}
 			}
 		}
+	}
+	// validate structs from file against input struct Type
+	if !validateStructType(allDeclaredTypes, options.StructType) {
+		return []byte{},
+			fmt.Errorf("%q structtype not found in input files",
+				options.StructType)
 	}
 
 	excludedMethods := make(map[string]struct{}, len(options.ExcludeMethods))


### PR DESCRIPTION
Using the following command line where `persister` contains files generated by [sqlc](https://github.com/sqlc-dev/sqlc), your [latest commit in master](https://github.com/vburenin/ifacemaker/commit/975a95966976eeb2d4365a7fb236e274c54da64c#r135172803) fails to correctly generate the file `./app/query.iface.go` because it cannot find the struct `Queries` in the **first** `.go` file.

```shell
ifacemaker -f ./persister/*.go -s Queries -i DataStoreQueries -p app -o ./app/query.iface.go
```
I moved the `if !validateStructType(...) {...}` to after the for loop and passed `allDeclaredTypes` instead of `types` and it allowed the file to be generated. I believe this is all that is needed for a fix.

