### PR TITLE
chore: Improve tests coverage of maker.go by 30%

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@ makes unit testing easier.
 
 ## Install
 
-```
+```console
 go install github.com/vburenin/ifacemaker@latest
 ```
 
 ## Usage
+
 Here is the help output of ifacemaker:
 
-```
+```console
 $ ifacemaker --help
 Usage:
   ifacemaker [OPTIONS]
@@ -41,43 +42,43 @@ $
 As an example, let's say you wanted to generate an interface for the Human structure
 in this sample code:
 
-```
+```go
 package main
 
 import "fmt"
 
 type Human struct {
-	name string
-	age  int
+ name string
+ age  int
 }
 
 // Returns the name of our Human.
 func (h *Human) GetName() string {
-	return h.name
+ return h.name
 }
 
 // Our Human just had a birthday! Increase its age.
 func (h *Human) Birthday() {
-	h.age += 1
-	fmt.Printf("I am now %d years old!\n", h.age)
+ h.age += 1
+ fmt.Printf("I am now %d years old!\n", h.age)
 }
 
 // Make the Human say hello.
 func (h *Human) SayHello() {
-	fmt.Printf("Hello, my name is %s, and I am %d years old.\n", h.name, h.age)
+ fmt.Printf("Hello, my name is %s, and I am %d years old.\n", h.name, h.age)
 }
 
 func main() {
-	human := &Human{name: "Bob", age: 30}
-	human.GetName()
-	human.SayHello()
-	human.Birthday()
+ human := &Human{name: "Bob", age: 30}
+ human.GetName()
+ human.SayHello()
+ human.Birthday()
 }
 ```
 
 The ifacemaker helper program can generate this interface for you:
 
-```
+```console
 $ ifacemaker -f human.go -s Human -i HumanIface -p humantest -y "HumanIface makes human interaction easy" -c "DONT EDIT: Auto generated"
 // DONT EDIT: Auto generated
 
@@ -85,12 +86,12 @@ package humantest
 
 // HumanIface makes human interaction easy
 type HumanIface interface {
-	// Returns the name of our Human.
-	GetName() string
-	// Our Human just had a birthday! Increase its age.
-	Birthday()
-	// Make the Human say hello.
-	SayHello()
+ // Returns the name of our Human.
+ GetName() string
+ // Our Human just had a birthday! Increase its age.
+ Birthday()
+ // Make the Human say hello.
+ SayHello()
 }
 
 $
@@ -103,14 +104,14 @@ ifacemaker program preserves docstrings by default.
 You can tell ifacemaker to write its output to a file, versus stdout, using the `-o`
 parameter:
 
-```
+```console
 $ ifacemaker -f human.go -s Human -i HumanIface -p humantest -y "HumanIface makes human interaction easy" -c "DONT EDIT: Auto generated" -o humaniface.go
 $
 ```
 
 You can also run it with `Docker`:
 
-```
+```console
 $ docker run --rm -v $(pwd):/tmp/ vburenin/ifacemaker -f /tmp/human.go -s Human -i HumanIface -p humantest -y "HumanIface makes human interaction easy" -c "DONT EDIT: Auto generated" -o /tmp/humaniface.go
 $
 ```

--- a/ifacemaker_test.go
+++ b/ifacemaker_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var src = `package main
@@ -209,7 +209,7 @@ type PersonIface interface {
 
 `
 
-	assert.Equal(t, expected, out)
+	require.Equal(t, expected, out)
 }
 
 func TestMainNoIfaceComment(t *testing.T) {
@@ -242,7 +242,7 @@ type PersonIface interface {
 		main()
 	})
 
-	assert.Equal(t, expected, out)
+	require.Equal(t, expected, out)
 
 }
 
@@ -274,7 +274,7 @@ type PersonIface interface {
 	out := captureStdout(func() {
 		main()
 	})
-	assert.Equal(t, expected, out)
+	require.Equal(t, expected, out)
 
 }
 
@@ -301,7 +301,7 @@ type PersonIface interface {
 		main()
 	})
 
-	assert.Equal(t, expected, out)
+	require.Equal(t, expected, out)
 
 }
 
@@ -322,7 +322,7 @@ type TestInterface interface {
 		main()
 	})
 
-	assert.Equal(t, expected, out)
+	require.Equal(t, expected, out)
 }
 
 func TestMainFileGlob(t *testing.T) {
@@ -341,7 +341,7 @@ type TestInterface interface {
 	out := captureStdout(func() {
 		main()
 	})
-	assert.Equal(t, expected, out)
+	require.Equal(t, expected, out)
 
 }
 
@@ -362,7 +362,7 @@ type TestInterface interface {
 		main()
 	})
 
-	assert.Equal(t, expected, out)
+	require.Equal(t, expected, out)
 }
 
 func TestMainUsingUnknownDeclarationInSamePackage(t *testing.T) {
@@ -385,7 +385,7 @@ type Smiter interface {
 		main()
 	})
 
-	assert.Equal(t, expected, out)
+	require.Equal(t, expected, out)
 }
 
 func TestMainUsingImportedDeclaration(t *testing.T) {
@@ -409,7 +409,7 @@ type Healer interface {
 		main()
 	})
 
-	assert.Equal(t, expected, out)
+	require.Equal(t, expected, out)
 }
 
 func TestMainWithMultipleFiles(t *testing.T) {
@@ -434,7 +434,7 @@ type Test interface {
 		main()
 	})
 
-	assert.Equal(t, expected, out)
+	require.Equal(t, expected, out)
 }
 
 // not thread safe

--- a/maker/maker_test.go
+++ b/maker/maker_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -112,19 +111,19 @@ func TestLines(t *testing.T) {
 	method := Method{Code: code, Docs: docs}
 	lines := method.Lines()
 
-	assert.Equal(t, "// TestMethod is great", lines[0])
-	assert.Equal(t, "func TestMethod() string {return \"I am great\"}", lines[1])
+	require.Equal(t, "// TestMethod is great", lines[0])
+	require.Equal(t, "func TestMethod() string {return \"I am great\"}", lines[1])
 }
 
 func TestParseDeclaredTypes(t *testing.T) {
 	declaredTypes := ParseDeclaredTypes(src)
 
-	assert.Equal(t, declaredType{
+	require.Equal(t, declaredType{
 		Name:    "Person",
 		Package: "main",
 	},
 		declaredTypes[0])
-	assert.Equal(t, declaredType{
+	require.Equal(t, declaredType{
 		Name:    "SomeType",
 		Package: "main",
 	},
@@ -134,26 +133,26 @@ func TestParseDeclaredTypes(t *testing.T) {
 func TestParseStruct(t *testing.T) {
 	methods, imports, typeDoc := ParseStruct(src, "Person", true, true, "", nil, "", false)
 
-	assert.Equal(t, "Name() (string)", methods[0].Code)
+	require.Equal(t, "Name() (string)", methods[0].Code)
 
 	imp := imports[0]
 	trimmedImp := strings.TrimSpace(imp)
 
-	assert.Equal(t, `notmain "fmt"`, trimmedImp)
-	assert.Equal(t, "Person ...", typeDoc)
+	require.Equal(t, `notmain "fmt"`, trimmedImp)
+	require.Equal(t, "Person ...", typeDoc)
 }
 
 func TestParseStructWithImportModule(t *testing.T) {
 	methods, imports, typeDoc := ParseStruct(src, "Person", true, true, "", nil, "github.com/test/test", false)
 
-	assert.Equal(t, "Name() (string)", methods[0].Code)
+	require.Equal(t, "Name() (string)", methods[0].Code)
 
 	imp, module := imports[0], imports[1]
 	trimmedImp := strings.TrimSpace(imp)
 
-	assert.Equal(t, `notmain "fmt"`, trimmedImp)
-	assert.Equal(t, `. "github.com/test/test"`, module)
-	assert.Equal(t, "Person ...", typeDoc)
+	require.Equal(t, `notmain "fmt"`, trimmedImp)
+	require.Equal(t, `. "github.com/test/test"`, module)
+	require.Equal(t, "Person ...", typeDoc)
 }
 
 func TestParseStructWithNotExported(t *testing.T) {
@@ -170,14 +169,14 @@ func TestParseStructWithNotExported(t *testing.T) {
 		}
 	}
 
-	assert.True(t, oneExists)
-	assert.True(t, twoExists)
+	require.True(t, oneExists)
+	require.True(t, twoExists)
 }
 
 func TestGetReceiverTypeName(t *testing.T) {
 	fset := token.NewFileSet()
 	a, err := parser.ParseFile(fset, "", src, parser.ParseComments)
-	assert.Nil(t, err, "ParseFile returned an error")
+	require.Nil(t, err, "ParseFile returned an error")
 
 	hasPersonFuncDecl := false
 	for _, d := range a.Decls {
@@ -187,19 +186,19 @@ func TestGetReceiverTypeName(t *testing.T) {
 		}
 		switch typeName {
 		case "Person":
-			assert.NotNil(t, fd, "receiver type with name %s had a nil func decl")
+			require.NotNil(t, fd, "receiver type with name %s had a nil func decl")
 			// OK
 			hasPersonFuncDecl = true
 		}
 	}
 
-	assert.True(t, hasPersonFuncDecl, "Never registered a func decl with the `Person` receiver type")
+	require.True(t, hasPersonFuncDecl, "Never registered a func decl with the `Person` receiver type")
 }
 
 func TestFormatFieldList(t *testing.T) {
 	fset := token.NewFileSet()
 	a, err := parser.ParseFile(fset, "", src, parser.ParseComments)
-	assert.Nil(t, err, "ParseFile returned an error")
+	require.Nil(t, err, "ParseFile returned an error")
 
 	for _, d := range a.Decls {
 		if a, fd := GetReceiverTypeName(src, d); a == "Person" {
@@ -241,22 +240,22 @@ func TestFormatFieldList(t *testing.T) {
 			case "SecondArgumentPointer":
 				expectedParams = []string{"abc int", "formatter *notmain.Formatter"}
 			}
-			assert.Equal(t, expectedParams, params)
-			assert.Equal(t, expectedResults, results)
+			require.Equal(t, expectedParams, params)
+			require.Equal(t, expectedResults, results)
 		}
 	}
 }
 
 func TestNoCopyTypeDocs(t *testing.T) {
 	_, _, typeDoc := ParseStruct(src, "Person", true, false, "", nil, "", false)
-	assert.Equal(t, "", typeDoc)
+	require.Equal(t, "", typeDoc)
 }
 
 func TestMakeInterface(t *testing.T) {
 	methods := []string{"// MyMethod does cool stuff", "MyMethod(string) example.Example"}
 	imports := []string{`"github.com/example/example"`}
 	b, err := MakeInterface("DO NOT EDIT: Auto generated", "pkg", "MyInterface", "MyInterface does cool stuff", methods, imports)
-	assert.Nil(t, err, "MakeInterface returned an error")
+	require.Nil(t, err, "MakeInterface returned an error")
 
 	expected := `// DO NOT EDIT: Auto generated
 
@@ -273,14 +272,14 @@ type MyInterface interface {
 }
 `
 
-	assert.Equal(t, expected, string(b))
+	require.Equal(t, expected, string(b))
 }
 
 func TestMakeWithoutInterfaceComment(t *testing.T) {
 	methods := []string{"// MyMethod does cool stuff", "MyMethod(string) example.Example"}
 	imports := []string{`"github.com/example/example"`}
 	b, err := MakeInterface("DO NOT EDIT: Auto generated", "pkg", "MyInterface", "", methods, imports)
-	assert.Nil(t, err, "MakeInterface returned an error")
+	require.Nil(t, err, "MakeInterface returned an error")
 
 	expected := `// DO NOT EDIT: Auto generated
 
@@ -296,14 +295,14 @@ type MyInterface interface {
 }
 `
 
-	assert.Equal(t, expected, string(b))
+	require.Equal(t, expected, string(b))
 }
 
 func TestMakeInterfaceWithGoGenerate(t *testing.T) {
 	methods := []string{"// MyMethod does cool stuff", "MyMethod(string) example.Example"}
 	imports := []string{`"github.com/example/example"`}
 	b, err := MakeInterface("DO NOT EDIT: Auto generated", "pkg", "MyInterface", "go:generate MyInterface does cool stuff", methods, imports)
-	assert.Nil(t, err, "MakeInterface returned an error")
+	require.Nil(t, err, "MakeInterface returned an error")
 
 	expected := `// DO NOT EDIT: Auto generated
 
@@ -320,12 +319,12 @@ type MyInterface interface {
 }
 `
 
-	assert.Equal(t, expected, string(b))
+	require.Equal(t, expected, string(b))
 }
 
 func TestMakeInterfaceMultiLineIfaceComment(t *testing.T) {
 	b, err := MakeInterface("DO NOT EDIT: Auto generated", "pkg", "MyInterface", "MyInterface does cool stuff.\nWith multi-line comments.", nil, nil)
-	assert.Nil(t, err, "MakeInterface returned an error:", err)
+	require.Nil(t, err, "MakeInterface returned an error:", err)
 
 	expected := `// DO NOT EDIT: Auto generated
 
@@ -337,7 +336,7 @@ type MyInterface interface {
 }
 `
 
-	assert.Equal(t, expected, string(b))
+	require.Equal(t, expected, string(b))
 }
 
 func Test_validate_struct_types(t *testing.T) {
@@ -370,7 +369,7 @@ func Test_validate_struct_types(t *testing.T) {
 			// test
 			got := validateStructType(types, tc.stType)
 			// validate
-			assert.Equal(t, tc.exp, got)
+			require.Equal(t, tc.exp, got)
 		})
 
 	}
@@ -379,7 +378,7 @@ func Test_validate_struct_types(t *testing.T) {
 
 func TestDeclaredTypeFullname(t *testing.T) {
 	dt := declaredType{Name: "Test", Package: "pkg"}
-	assert.Equal(t, "pkg.Test", dt.Fullname())
+	require.Equal(t, "pkg.Test", dt.Fullname())
 }
 
 func TestGetTypeDeclarationName_Valid(t *testing.T) {
@@ -396,7 +395,7 @@ func TestGetTypeDeclarationName_Valid(t *testing.T) {
 			break
 		}
 	}
-	assert.Equal(t, "MyType", found)
+	require.Equal(t, "MyType", found)
 }
 
 func TestGetTypeDeclarationName_NonTypeDecl(t *testing.T) {
@@ -408,7 +407,7 @@ func TestGetTypeDeclarationName_NonTypeDecl(t *testing.T) {
 	for _, d := range file.Decls {
 		name := GetTypeDeclarationName(d)
 		// For non-type declarations, the function should return an empty string.
-		assert.Equal(t, "", name)
+		require.Equal(t, "", name)
 	}
 }
 
@@ -419,27 +418,27 @@ func TestGetReceiverType_NotMethod(t *testing.T) {
 		Name: ast.NewIdent("Func"),
 	}
 	_, err := GetReceiverType(fd)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestFormatCodeValid(t *testing.T) {
 	code := "package main\nfunc main(){println(\"hello\")}"
 	formatted, err := FormatCode(code)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Check that the formatted code contains the package declaration.
-	assert.Contains(t, string(formatted), "package main")
+	require.Contains(t, string(formatted), "package main")
 }
 
 func TestFormatCodeInvalid(t *testing.T) {
 	// Providing a code fragment that is not valid Go code.
 	code := "not a valid go code"
 	_, err := FormatCode(code)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestFormatFieldList_Nil(t *testing.T) {
 	parts := FormatFieldList([]byte(""), nil, "main", nil)
-	assert.Nil(t, parts)
+	require.Nil(t, parts)
 }
 
 func TestMakeStructNotFound(t *testing.T) {
@@ -460,9 +459,9 @@ func TestMakeStructNotFound(t *testing.T) {
 		PkgName:    "main",
 		IfaceName:  "TestIface",
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 	// Update expected substring to include the quotes
-	assert.Contains(t, err.Error(), `"NonExistent" structtype not found`)
+	require.Contains(t, err.Error(), `"NonExistent" structtype not found`)
 }
 
 func TestMakeFileNotFound(t *testing.T) {
@@ -474,14 +473,14 @@ func TestMakeFileNotFound(t *testing.T) {
 		PkgName:    "main",
 		IfaceName:  "TestIface",
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 // TestParseDeclaredTypesEmpty ensures that a source with no type declarations returns an empty slice.
 func TestParseDeclaredTypesEmpty(t *testing.T) {
 	src := []byte("package main\nfunc Foo() {}")
 	types := ParseDeclaredTypes(src)
-	assert.Empty(t, types)
+	require.Empty(t, types)
 }
 
 // TestFormatFieldList_MultipleNames verifies that parameters with multiple names are formatted correctly.
@@ -502,7 +501,7 @@ func Foo(a, b int) int { return 0 }`)
 	require.NotNil(t, fd)
 	params := FormatFieldList(src, fd.Type.Params, "main", nil)
 	// Expect parameters to be formatted as "a, b int"
-	assert.Contains(t, params, "a, b int")
+	require.Contains(t, params, "a, b int")
 }
 
 // TestGetReceiverTypeName_NonPointer checks that a non-pointer receiver is handled without stripping extra characters.
@@ -520,11 +519,11 @@ func (m MyStruct) Foo() {}`)
 		if typeName == "MyStruct" {
 			found = true
 			// Should not have a leading '*' since receiver is not a pointer.
-			assert.Equal(t, "MyStruct", typeName)
-			assert.Equal(t, "Foo", fd.Name.Name)
+			require.Equal(t, "MyStruct", typeName)
+			require.Equal(t, "Foo", fd.Name.Name)
 		}
 	}
-	assert.True(t, found, "Expected to find a receiver with type 'MyStruct'")
+	require.True(t, found, "Expected to find a receiver with type 'MyStruct'")
 }
 
 // TestMakeExcludeMethod ensures that methods listed in the exclusion set are omitted.
@@ -554,8 +553,8 @@ func (m *MyStruct) Bar() {}
 	})
 	require.NoError(t, err)
 	outStr := string(result)
-	assert.Contains(t, outStr, "Foo()")
-	assert.NotContains(t, outStr, "Bar()")
+	require.Contains(t, outStr, "Foo()")
+	require.NotContains(t, outStr, "Bar()")
 }
 
 // TestMakeDuplicateMethods verifies that if the same method is present in multiple files, it appears only once.
@@ -594,5 +593,5 @@ func (m *MyStruct) Foo() {}
 	outStr := string(result)
 	// The method Foo() should appear only once.
 	count := strings.Count(outStr, "Foo()")
-	assert.Equal(t, 1, count)
+	require.Equal(t, 1, count)
 }

--- a/maker/maker_test.go
+++ b/maker/maker_test.go
@@ -563,7 +563,7 @@ func TestMakeDuplicateMethods(t *testing.T) {
 type MyStruct struct {}
 func (m *MyStruct) Foo() {}
 `)
-	src2 := []byte(`package main
+	src2 := []byte(`package other
 type MyStruct struct {}
 func (m *MyStruct) Foo() {}
 `)


### PR DESCRIPTION
- Improve tests coverage for `maker.go` from 67.1% to 96.8%

Related #70 