### PR TITLE
♻ Refactor: Fix maker.go wrong mName logic

### DIFF
--- a/maker/maker.go
+++ b/maker/maker.go
@@ -529,6 +529,7 @@ func Make(options MakeOptions) ([]byte, error) {
 				continue
 			}
 
+			// Use m.Name as the key to ensure uniqueness of methods in mset.
 			if _, ok := mset[m.Name]; !ok {
 				allMethods = append(allMethods, m.Lines()...)
 				mset[m.Name] = struct{}{}

--- a/maker/maker.go
+++ b/maker/maker.go
@@ -351,12 +351,15 @@ func ParseStruct(src []byte, structName string, copyDocs bool, copyTypeDocs bool
 	// Process direct methods first
 	for _, d := range a.Decls {
 		if a, fd := GetReceiverTypeName(src, d); a == structName {
+			mName := fd.Name.String()
+			if _, ok := methodSet[mName]; ok {
+				continue
+			}
 			if !withNotExported && !fd.Name.IsExported() {
 				continue
 			}
 			params := FormatFieldList(src, fd.Type.Params, pkgName, declaredTypes)
 			ret := FormatFieldList(src, fd.Type.Results, pkgName, declaredTypes)
-			mName := fd.Name.String()
 			method := fmt.Sprintf("%s(%s) (%s)", mName, strings.Join(params, ", "), strings.Join(ret, ", "))
 			var docs []string
 			if fd.Doc != nil && copyDocs {
@@ -526,9 +529,9 @@ func Make(options MakeOptions) ([]byte, error) {
 				continue
 			}
 
-			if _, ok := mset[m.Code]; !ok {
+			if _, ok := mset[m.Name]; !ok {
 				allMethods = append(allMethods, m.Lines()...)
-				mset[m.Code] = struct{}{}
+				mset[m.Name] = struct{}{}
 			}
 		}
 		for _, i := range imports {


### PR DESCRIPTION
I found a hidden issue in `maker.go` that was missed in #80 and #83.

### Code Change
Change the `mset` key from `m.Code` -> `m.Name`

Using `m.Code` would cause duplicate methods to be added to an interface if two versions of a promoted method exist, simply due to the code having a different struct name.